### PR TITLE
add overload to filter with typeguard predicate

### DIFF
--- a/asynciter.ts
+++ b/asynciter.ts
@@ -29,6 +29,9 @@ export interface IAsyncIter<T> extends AsyncIterable<T> {
     concurrency?: number,
   ): IAsyncIter<U>;
 
+  filter<U extends T>(
+    filterFn: (item: T) => item is U,
+  ): IAsyncIter<U>;
   filter(
     filterFn: (item: T) => boolean | Promise<boolean>,
   ): IAsyncIter<T>;
@@ -136,6 +139,12 @@ export class AsyncIter<T> implements IAsyncIter<T> {
     });
   }
 
+  filter<U extends T>(
+    filterFn: (item: T) => item is U,
+  ): AsyncIter<U>;
+  filter(
+    filterFn: (item: T) => boolean | Promise<boolean>,
+  ): AsyncIter<T>;
   /**
    * Filter the sequence to contain just the items that pass a test.
    * @param filterFn The filter function.

--- a/filter.ts
+++ b/filter.ts
@@ -1,3 +1,11 @@
+export function filter<T, U extends T>(
+  iterable: AsyncIterable<T>,
+  filterFn: (item: T) => item is U,
+): AsyncIterableIterator<U>;
+export function filter<T>(
+  iterable: AsyncIterable<T>,
+  filterFn: (item: T) => boolean | Promise<boolean>,
+): AsyncIterableIterator<T>;
 /**
  * Filter the sequence to contain just the items that pass a test.
  * @param iterable An iterable collection.


### PR DESCRIPTION
We can convert the type of item by specifying a type-guard function to filter.
Note that this is not available for async filter functions, because Typescript does not have async type-guard syntax.

```typescript
import { asynciter } from "./asynciter.ts";

const isString = (item: unknown): item is string => typeof item === "string";

const iter = asynciter(["foo", 42]); // => IAsyncIter<string | number>

const stringIter = iter.filter(isString); // => IAsyncIter<string>
```